### PR TITLE
Rename encryptionkey resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
-	github.com/giantswarm/apiextensions v0.0.0-20200203210354-9c7040d3c59f
+	github.com/giantswarm/apiextensions v0.0.0-20200211154704-cbcf4d4b80bf
 	github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192 // indirect
 	github.com/giantswarm/exporterkit v0.0.0-20190619131829-9749deade60f // indirect
 	github.com/giantswarm/k8sclient v0.0.0-20200120104955-1542917096d6

--- a/go.sum
+++ b/go.sum
@@ -79,12 +79,8 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/giantswarm/apiextensions v0.0.0-20200203210354-9c7040d3c59f h1:Ri9/MSH3txRhDjnRzwGRtusyQFZ52+U6VXeZtZU2XIw=
-github.com/giantswarm/apiextensions v0.0.0-20200203210354-9c7040d3c59f/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/apiextensions v0.0.0-20200211154704-cbcf4d4b80bf h1:NC1PoDs83g4ihVqQhRvfgsw1Sfa8WlCwoJo1kd0kmBs=
 github.com/giantswarm/apiextensions v0.0.0-20200211154704-cbcf4d4b80bf/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
-github.com/giantswarm/apiextensions v0.0.0-20200212113354-73abff44e459 h1:XiHbFhfXspvbMSE4fKm7ShfwxPsuK4rI7WSVl8UtlXw=
-github.com/giantswarm/apiextensions v0.0.0-20200212113354-73abff44e459/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192 h1:jguq2nu1gbvP6OQIqmkUlbl4ekpwSRUPiXUWlF8InyQ=
 github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192/go.mod h1:kjItv/iHgl/xsprYgbnCOme1pVTiiiaZeR2ybsN4ab0=
 github.com/giantswarm/exporterkit v0.0.0-20190619131829-9749deade60f h1:k5IxVNqFYdi2sMmnF8/fHu/udi2BylmBpWgMQFKwIyQ=

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,10 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ER
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/giantswarm/apiextensions v0.0.0-20200203210354-9c7040d3c59f h1:Ri9/MSH3txRhDjnRzwGRtusyQFZ52+U6VXeZtZU2XIw=
 github.com/giantswarm/apiextensions v0.0.0-20200203210354-9c7040d3c59f/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
+github.com/giantswarm/apiextensions v0.0.0-20200211154704-cbcf4d4b80bf h1:NC1PoDs83g4ihVqQhRvfgsw1Sfa8WlCwoJo1kd0kmBs=
+github.com/giantswarm/apiextensions v0.0.0-20200211154704-cbcf4d4b80bf/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
+github.com/giantswarm/apiextensions v0.0.0-20200212113354-73abff44e459 h1:XiHbFhfXspvbMSE4fKm7ShfwxPsuK4rI7WSVl8UtlXw=
+github.com/giantswarm/apiextensions v0.0.0-20200212113354-73abff44e459/go.mod h1:zHLSgCszRMdZUzwmfOibzcyfRC89ygwAQlpXcukgZuc=
 github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192 h1:jguq2nu1gbvP6OQIqmkUlbl4ekpwSRUPiXUWlF8InyQ=
 github.com/giantswarm/backoff v0.0.0-20190913091243-4dd491125192/go.mod h1:kjItv/iHgl/xsprYgbnCOme1pVTiiiaZeR2ybsN4ab0=
 github.com/giantswarm/exporterkit v0.0.0-20190619131829-9749deade60f h1:k5IxVNqFYdi2sMmnF8/fHu/udi2BylmBpWgMQFKwIyQ=

--- a/service/controller/controllercontext/spec.go
+++ b/service/controller/controllercontext/spec.go
@@ -38,7 +38,6 @@ type ContextSpecDockerNetworkSetup struct {
 
 type ContextSpecEtcd struct {
 	Domain string
-	Image  string
 	Port   int
 	Prefix string
 }
@@ -100,7 +99,6 @@ type ContextSpecKubernetes struct {
 	DNS     ContextSpecKubernetesDNS
 	Domain  string
 	Kubelet ContextSpecKubernetesKubelet
-	Image   string
 	IPRange string
 }
 

--- a/service/controller/controllercontext/spec.go
+++ b/service/controller/controllercontext/spec.go
@@ -38,6 +38,7 @@ type ContextSpecDockerNetworkSetup struct {
 
 type ContextSpecEtcd struct {
 	Domain string
+	Image  string
 	Port   int
 	Prefix string
 }
@@ -99,6 +100,7 @@ type ContextSpecKubernetes struct {
 	DNS     ContextSpecKubernetesDNS
 	Domain  string
 	Kubelet ContextSpecKubernetesKubelet
+	Image   string
 	IPRange string
 }
 

--- a/service/controller/ignition_resource_set.go
+++ b/service/controller/ignition_resource_set.go
@@ -14,7 +14,7 @@ import (
 	"github.com/giantswarm/ignition-operator/pkg/project"
 	"github.com/giantswarm/ignition-operator/service/controller/controllercontext"
 	"github.com/giantswarm/ignition-operator/service/controller/key"
-	"github.com/giantswarm/ignition-operator/service/controller/resource/encryptionkey"
+	"github.com/giantswarm/ignition-operator/service/controller/resource/contextspec"
 	"github.com/giantswarm/ignition-operator/service/controller/resource/templatefiles"
 	"github.com/giantswarm/ignition-operator/service/controller/resource/templateignition"
 	"github.com/giantswarm/ignition-operator/service/controller/resource/templateunits"
@@ -30,12 +30,12 @@ func newIgnitionResourceSet(config ignitionResourceSetConfig) (*controller.Resou
 
 	var encryptionkeyResource resource.Interface
 	{
-		c := encryptionkey.Config{
+		c := contextspec.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 		}
 
-		encryptionkeyResource, err = encryptionkey.New(c)
+		encryptionkeyResource, err = contextspec.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/ignition_resource_set.go
+++ b/service/controller/ignition_resource_set.go
@@ -28,14 +28,14 @@ type ignitionResourceSetConfig struct {
 func newIgnitionResourceSet(config ignitionResourceSetConfig) (*controller.ResourceSet, error) {
 	var err error
 
-	var encryptionkeyResource resource.Interface
+	var contextspecResource resource.Interface
 	{
 		c := contextspec.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 		}
 
-		encryptionkeyResource, err = contextspec.New(c)
+		contextspecResource, err = contextspec.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -80,7 +80,7 @@ func newIgnitionResourceSet(config ignitionResourceSetConfig) (*controller.Resou
 	}
 
 	resources := []resource.Interface{
-		encryptionkeyResource,
+		contextspecResource,
 		templatefilesResource,
 		templateunitsResource,
 		templateignitionResource,

--- a/service/controller/resource/contextspec/create.go
+++ b/service/controller/resource/contextspec/create.go
@@ -1,4 +1,4 @@
-package encryptionkey
+package contextspec
 
 import (
 	"context"
@@ -98,7 +98,6 @@ func crToCCSpec(cr v1alpha1.Ignition) controllercontext.ContextSpec {
 			},
 			Etcd: controllercontext.ContextSpecEtcd{
 				Domain: cr.Spec.Etcd.Domain,
-				Image:  cr.Spec.Etcd.Image,
 				Port:   cr.Spec.Etcd.Port,
 				Prefix: cr.Spec.Etcd.Prefix,
 			},
@@ -122,7 +121,6 @@ func crToCCSpec(cr v1alpha1.Ignition) controllercontext.ContextSpec {
 				Kubelet: controllercontext.ContextSpecKubernetesKubelet{
 					Domain: cr.Spec.Kubernetes.Kubelet.Domain,
 				},
-				Image:   cr.Spec.Kubernetes.Image,
 				IPRange: cr.Spec.Kubernetes.IPRange,
 			},
 			Provider: cr.Spec.Provider,

--- a/service/controller/resource/contextspec/delete.go
+++ b/service/controller/resource/contextspec/delete.go
@@ -1,4 +1,4 @@
-package encryptionkey
+package contextspec
 
 import (
 	"context"

--- a/service/controller/resource/contextspec/error.go
+++ b/service/controller/resource/contextspec/error.go
@@ -1,4 +1,4 @@
-package encryptionkey
+package contextspec
 
 import (
 	"github.com/giantswarm/microerror"

--- a/service/controller/resource/contextspec/resource.go
+++ b/service/controller/resource/contextspec/resource.go
@@ -1,4 +1,4 @@
-package encryptionkey
+package contextspec
 
 import (
 	"github.com/giantswarm/k8sclient"
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "encryptionkey"
+	Name = "contextspec"
 )
 
 type Config struct {

--- a/service/controller/resource/templatefiles/create.go
+++ b/service/controller/resource/templatefiles/create.go
@@ -9,10 +9,6 @@ import (
 	"github.com/giantswarm/ignition-operator/service/controller/key"
 )
 
-const (
-	filesdir = "/files"
-)
-
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/8641

Since this is turning ignition into the context spec which is used for templating, I decided to call it `contextspec`. Also took this opportunity to use the latest version of the `apiextensions` ignition branch.