### PR TITLE
Add missing values for Helm linting

### DIFF
--- a/helm/ignition-operator/Chart.yaml
+++ b/helm/ignition-operator/Chart.yaml
@@ -1,3 +1,6 @@
 apiVersion: v1
 name: ignition-operator
+description: Templates ignition which is used for giantswarm clusters.
+home: https://github.com/giantswarm/ignition-operator
 version: [[ .Version ]]
+appVersion: [[ .Version ]]

--- a/helm/ignition-operator/ci/default-values.yaml
+++ b/helm/ignition-operator/ci/default-values.yaml
@@ -1,0 +1,7 @@
+---
+Installation:
+  V1:
+    Secret:
+      Registry:
+        PullSecret:
+          DockerConfigJSON: {}


### PR DESCRIPTION
We will be using `ct` (https://github.com/helm/chart-testing) and this commit
adds some missing values to ensure that linting passes without a problem.

yaml files under helm/ignition-operator/ci/ are dummy value files that are used
by the linter to template against. It is possible to have more than one yaml
file and the linter will test against each of these.