### PR TITLE
pkg, service: replace `bundleVersion` with `version`

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,17 +1,12 @@
 package project
 
 var (
-	bundleVersion = "0.0.1"
-	description   = "The ignition-operator does something."
-	gitSHA        = "n/a"
-	name          = "ignition-operator"
-	source        = "https://github.com/giantswarm/ignition-operator"
-	version       = "n/a"
+	description = "The ignition-operator does something."
+	gitSHA      = "n/a"
+	name        = "ignition-operator"
+	source      = "https://github.com/giantswarm/ignition-operator"
+	version     = "0.0.1"
 )
-
-func BundleVersion() string {
-	return bundleVersion
-}
 
 func Description() string {
 	return description

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -15,6 +15,6 @@ func NewVersionBundle() versionbundle.Bundle {
 		},
 		Components: []versionbundle.Component{},
 		Name:       "ignition-operator",
-		Version:    BundleVersion(),
+		Version:    Version(),
 	}
 }

--- a/service/controller/ignition_resource_set.go
+++ b/service/controller/ignition_resource_set.go
@@ -112,7 +112,7 @@ func newIgnitionResourceSet(config ignitionResourceSetConfig) (*controller.Resou
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.BundleVersion() {
+		if key.OperatorVersion(&cr) == project.Version() {
 			return true
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8637

We want to invert how the project version is maintained and now that
it isn't injected during the build from git data, we can remove the
separate concept of _bundle version_ and replace it with just _version_.