### PR TITLE
helm: Ensure proper labels on all resources

### DIFF
--- a/helm/ignition-operator/Chart.yaml
+++ b/helm/ignition-operator/Chart.yaml
@@ -3,4 +3,4 @@ name: ignition-operator
 description: Templates ignition which is used for giantswarm clusters.
 home: https://github.com/giantswarm/ignition-operator
 version: [[ .Version ]]
-appVersion: [[ .Version ]]
+appVersion: [[ .AppVersion ]]

--- a/helm/ignition-operator/templates/_helpers.tpl
+++ b/helm/ignition-operator/templates/_helpers.tpl
@@ -17,8 +17,8 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "ignition-operator.labels" -}}
-app: {{ include "ignition-operator.name" . | quote }}
 {{ include "ignition-operator.selectorLabels" . }}
+app: {{ include "ignition-operator.name" . | quote }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/helm/ignition-operator/templates/_helpers.tpl
+++ b/helm/ignition-operator/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ignition-operator.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ignition-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "ignition-operator.labels" -}}
+app: {{ include "ignition-operator.name" . | quote }}
+{{ include "ignition-operator.selectorLabels" . }}
+app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
+app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ include "ignition-operator.chart" . | quote }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ignition-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ignition-operator.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end -}}

--- a/helm/ignition-operator/templates/configmap.yaml
+++ b/helm/ignition-operator/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 data:
   config.yml: |
     server:

--- a/helm/ignition-operator/templates/deployment.yaml
+++ b/helm/ignition-operator/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "ignition-operator.labels" . | nindent 8 }}
+        {{- include "ignition-operator.selectorLabels" . | nindent 8 }}
       annotations:
         releasetime: {{ $.Release.Time }}
     spec:

--- a/helm/ignition-operator/templates/deployment.yaml
+++ b/helm/ignition-operator/templates/deployment.yaml
@@ -4,21 +4,18 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Values.project.name }}
-      version: {{ .Values.project.version }}
+      {{- include "ignition-operator.selectorLabels" . | nindent 6 }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: {{ .Values.project.name }}
-        version: {{ .Values.project.version }}
+        {{- include "ignition-operator.labels" . | nindent 8 }}
       annotations:
         releasetime: {{ $.Release.Time }}
     spec:
@@ -28,12 +25,11 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: {{ .Values.project.name }}
-                  version: {{ .Values.project.version }}
+                  {{- include "ignition-operator.selectorLabels" . | nindent 18 }}
               topologyKey: kubernetes.io/hostname
             weight: 100
       volumes:
-      - name: {{ .Values.project.name }}-configmap
+      - name: {{ .Chart.Name }}-configmap
         configMap:
           name: {{ tpl .Values.resource.default.name  . }}
           items:
@@ -44,15 +40,15 @@ spec:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
       containers:
-      - name: {{ .Values.project.name }}
+      - name: {{ .Chart.Name }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         args:
         - daemon
-        - --config.dirs=/var/run/{{ .Values.project.name }}/configmap/
+        - --config.dirs=/var/run/{{ .Chart.Name }}/configmap/
         - --config.files=config
         volumeMounts:
-        - name: {{ .Values.project.name }}-configmap
-          mountPath: /var/run/{{ .Values.project.name }}/configmap/
+        - name: {{ .Chart.Name }}-configmap
+          mountPath: /var/run/{{ .Chart.Name }}/configmap/
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/ignition-operator/templates/psp.yaml
+++ b/helm/ignition-operator/templates/psp.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/ignition-operator/templates/pull-secret.yaml
+++ b/helm/ignition-operator/templates/pull-secret.yaml
@@ -5,5 +5,7 @@ type: kubernetes.io/dockerconfigjson
 metadata:
   name: {{ tpl .Values.resource.pullSecret.name . }}
   namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/ignition-operator/templates/rbac.yaml
+++ b/helm/ignition-operator/templates/rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - core.giantswarm.io
@@ -66,6 +68,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ tpl .Values.resource.default.name  . }}
@@ -79,6 +83,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - extensions
@@ -93,6 +99,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ tpl .Values.resource.default.name  . }}

--- a/helm/ignition-operator/templates/service-account.yaml
+++ b/helm/ignition-operator/templates/service-account.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "ignition-operator.labels" . | nindent 4 }}

--- a/helm/ignition-operator/templates/service.yaml
+++ b/helm/ignition-operator/templates/service.yaml
@@ -4,13 +4,11 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "ignition-operator.labels" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: 8000
   selector:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "ignition-operator.selectorLabels" . | nindent 4 }}

--- a/helm/ignition-operator/values.yaml
+++ b/helm/ignition-operator/values.yaml
@@ -8,8 +8,8 @@ pod:
   group:
     id: 1000
 project:
-  name: "ignition-operator"
-  version: "[[ .Version ]]"
+  branch: "[[ .Branch ]]"
+  commit: "[[ .SHA ]]"
 # Resource names are truncated to 47 characters.
 #
 # Kubernetes allows 63 characters limit for resource names. When pods for


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8632

Refactor labels out into a template helper to be able to maintain them
in one place and use on multiple objects. This borrows from a structure
of a default chart template in upstream Helm.

Ensure all resources created when the chart is installed have proper
labels, i.e. `app.kubernetes.io/name` together with
`app.kubernetes.io/instance` used as selector, as well as
`app.kubernetes.io/version`, `app.giantswarm.io/branch` and
`app.giantswarm.io/commit` - purely informational.

This includes other common labels advocated by Kubernetes
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
so that resources can be queried and visualised by shared tooling.

Expect _architect_ to inject `AppVersion` as the version from
`project.go`.

Also drop `project.name` and `project.version` variables from
`values.yaml` in the chart. In new operators the chart name is equal to
app name so we can remove a customisation option which doesn't bring
much value and just use the chart name directly.
