### PR TITLE
Automatically tidy dependabot PRs

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,0 +1,40 @@
+# Credit: https://github.com/crazy-max/diun
+name: auto-go-mod-tidy
+
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v1
+      -
+        # https://github.com/actions/checkout/issues/6
+        name: Fix detached HEAD
+        run: git checkout ${GITHUB_REF#refs/heads/}
+      -
+        name: Tidy
+        run: |
+          rm -f go.sum
+          go mod tidy
+      -
+        name: Set up Git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+      -
+        name: Commit and push changes
+        run: |
+          git add .
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'Fix go modules'
+            git push
+          fi


### PR DESCRIPTION
This has only been partially tested thus far because it needs dependabot to push a commit. Want to try on ignition-operator, worst case is the PRs don't get tidied